### PR TITLE
Update Photon security advisories in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,21 +3,21 @@ Collect vulnerability information and save it in parsable format automatically
 
 ## Source
 
-| Directory   | OS               |              Source             | URL                                                 |
-|-------------|------------------|:-------------------------------:|-----------------------------------------------------|
-| alpine/     | Alpine Linux     | Alpine secdb                    | https://secdb.alpinelinux.org/                      |
-| amazon/1    | Amazon Linux     | Amazon Linux Security Center    | https://alas.aws.amazon.com/                        |
-| amazon/2    | Amazon Linux 2   | Amazon Linux Security Center    | https://alas.aws.amazon.com/alas2.html              |
-| debian/     | Debian GNU/Linux | Security Bug Tracker            | https://security-tracker.debian.org/tracker/        |
-| nvd/        | -                | National Vulnerability Database | https://nvd.nist.gov/                               |
-| oval/debian | Debian GNU/Linux | OVAL                            | https://www.debian.org/security/oval/               |
-| oval/oracle | Oracle Linux     | OVAL                            | https://linux.oracle.com/security/oval/             |
-| oval/redhat | RHEL/CentOS      | OVAL                            | https://www.redhat.com/security/data/oval/v2/       |
-| redhat/     | RHEL/CentOS      | Security Data                   | https://www.redhat.com/security/data/metrics/       |
-| ubuntu/     | Ubuntu           | Ubuntu CVE Tracker              | https://people.canonical.com/~ubuntu-security/cve/  |
-| cvrf/suse   | OpenSUSE/SLES    | SUSE Security CVRF              | http://ftp.suse.com/pub/projects/security/cvrf/     |
-| photon/     | Photon           | Photon Security Advisory        | https://vmware.bintray.com/photon_cve_metadata/     |
-| ghsa/       | -                | GitHub Advisory Database        | https://github.com/advisories/                      |
+| Directory   | OS               |              Source             | URL                                                                                                                   |
+|-------------|------------------|:-------------------------------:|-----------------------------------------------------------------------------------------------------------------------|
+| alpine/     | Alpine Linux     | Alpine secdb                    | https://secdb.alpinelinux.org/                                                                                        |
+| amazon/1    | Amazon Linux     | Amazon Linux Security Center    | https://alas.aws.amazon.com/                                                                                          |
+| amazon/2    | Amazon Linux 2   | Amazon Linux Security Center    | https://alas.aws.amazon.com/alas2.html                                                                                |
+| debian/     | Debian GNU/Linux | Security Bug Tracker            | https://security-tracker.debian.org/tracker/                                                                          |
+| nvd/        | -                | National Vulnerability Database | https://nvd.nist.gov/                                                                                                 |
+| oval/debian | Debian GNU/Linux | OVAL                            | https://www.debian.org/security/oval/                                                                                 |
+| oval/oracle | Oracle Linux     | OVAL                            | https://linux.oracle.com/security/oval/                                                                               |
+| oval/redhat | RHEL/CentOS      | OVAL                            | https://www.redhat.com/security/data/oval/v2/                                                                         |
+| redhat/     | RHEL/CentOS      | Security Data                   | https://www.redhat.com/security/data/metrics/                                                                         |
+| ubuntu/     | Ubuntu           | Ubuntu CVE Tracker              | https://people.canonical.com/~ubuntu-security/cve/                                                                    |
+| cvrf/suse   | OpenSUSE/SLES    | SUSE Security CVRF              | http://ftp.suse.com/pub/projects/security/cvrf/                                                                       |
+| photon/     | Photon           | Photon Security Advisory        | https://github.com/vmware/photon/wiki/Security-Advisories<br>https://packages.vmware.com/photon/photon_cve_metadata/  |
+| ghsa/       | -                | GitHub Advisory Database        | https://github.com/advisories/                                                                                        |
 
 ## Update frequency
 daily


### PR DESCRIPTION
- Current link in README for Photon is no longer valid
- Add Photon security advisories URL
- Add Photon `photon_cve_metadata` endpoint, which is currently leveraged in [`vuln-list-update`](https://github.com/aquasecurity/vuln-list-update/blob/main/photon/photon.go#L17)